### PR TITLE
Correct Mongoose update method name

### DIFF
--- a/controllers/bootcamps.js
+++ b/controllers/bootcamps.js
@@ -76,7 +76,7 @@ exports.updateBootcamp = asyncHandler(async (req, res, next) => {
     );
   }
 
-  bootcamp = await Bootcamp.findOneAndUpdate(req.params.id, req.body, {
+  bootcamp = await Bootcamp.findByIdAndUpdate(req.params.id, req.body, {
     new: true,
     runValidators: true
   });


### PR DESCRIPTION
The method here should be `findByIdAndUpdate`, instead of `findOneAndUpdate`.

Note: the other controller files are fine; they all use `findByIdAndUpdate`.

This fix was inspired by an issue from Udemy: https://www.udemy.com/course/nodejs-api-masterclass/learn/lecture/16582212#questions/9021124