### PR TITLE
Add await to bootcamp delete

### DIFF
--- a/controllers/bootcamps.js
+++ b/controllers/bootcamps.js
@@ -106,7 +106,7 @@ exports.deleteBootcamp = asyncHandler(async (req, res, next) => {
     );
   }
 
-  bootcamp.remove();
+  await bootcamp.remove();
 
   res.status(200).json({ success: true, data: {} });
 });


### PR DESCRIPTION
User (@TurtleWolfe) from Udemy found a missing `await` inside the `deleteBootcamp` method (controllers/bootcamps.js).