### PR TITLE
Changing logout comment from Private to Public

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -51,7 +51,7 @@ exports.login = asyncHandler(async (req, res, next) => {
 
 // @desc      Log user out / clear cookie
 // @route     GET /api/v1/auth/logout
-// @access    Private
+// @access    Public
 exports.logout = asyncHandler(async (req, res, next) => {
   res.cookie('token', 'none', {
     expires: new Date(Date.now() + 10 * 1000),


### PR DESCRIPTION
Hi,

The @access comment in the auth.js controller said 'Private' when in fact we made it as a 'Public' functionality. Cross checked with auth.js routes file and we haven't used protect there so this change makes sense.

Thanks :)