### PR TITLE
Activate Mongoose pre "save" hooks when updating courses/reviews

### DIFF
--- a/controllers/courses.js
+++ b/controllers/courses.js
@@ -105,6 +105,8 @@ exports.updateCourse = asyncHandler(async (req, res, next) => {
     runValidators: true
   });
 
+  course.save();
+
   res.status(200).json({
     success: true,
     data: course

--- a/controllers/reviews.js
+++ b/controllers/reviews.js
@@ -90,6 +90,8 @@ exports.updateReview = asyncHandler(async (req, res, next) => {
     runValidators: true
   });
 
+  review.save();
+
   res.status(200).json({
     success: true,
     data: review


### PR DESCRIPTION
When updating a course (with a new cost) or updating a review (with a new rating), the associated models' pre "save" hooks **aren't** being triggered.

If you add a `course.save()`, for example, then these hooks will be properly called.

Credit goes **_Moshe_**, a student from Udemy.