### PR TITLE
Pagination Bug with Custom Queries

### DIFF
--- a/middleware/advancedResults.js
+++ b/middleware/advancedResults.js
@@ -38,7 +38,7 @@ const advancedResults = (model, populate) => async (req, res, next) => {
   const limit = parseInt(req.query.limit, 10) || 25;
   const startIndex = (page - 1) * limit;
   const endIndex = page * limit;
-  const total = await model.countDocuments();
+  const total = await model.countDocuments(JSON.parse(queryStr));
 
   query = query.skip(startIndex).limit(limit);
 

--- a/models/Course.js
+++ b/models/Course.js
@@ -67,13 +67,13 @@ CourseSchema.statics.getAverageCost = async function(bootcampId) {
 };
 
 // Call getAverageCost after save
-CourseSchema.post('save', function() {
-  this.constructor.getAverageCost(this.bootcamp);
+CourseSchema.post('save', async function() {
+  await this.constructor.getAverageCost(this.bootcamp);
 });
 
 // Call getAverageCost before remove
-CourseSchema.pre('remove', function() {
-  this.constructor.getAverageCost(this.bootcamp);
+CourseSchema.pre('remove', async function() {
+  await this.constructor.getAverageCost(this.bootcamp);
 });
 
 module.exports = mongoose.model('Course', CourseSchema);

--- a/models/Review.js
+++ b/models/Review.js
@@ -60,13 +60,13 @@ ReviewSchema.statics.getAverageRating = async function(bootcampId) {
 };
 
 // Call getAverageCost after save
-ReviewSchema.post('save', function() {
-  this.constructor.getAverageRating(this.bootcamp);
+ReviewSchema.post('save', async function() {
+  await this.constructor.getAverageRating(this.bootcamp);
 });
 
 // Call getAverageCost before remove
-ReviewSchema.pre('remove', function() {
-  this.constructor.getAverageRating(this.bootcamp);
+ReviewSchema.pre('remove', async function() {
+  await this.constructor.getAverageRating(this.bootcamp);
 });
 
 module.exports = mongoose.model('Review', ReviewSchema);


### PR DESCRIPTION
When a user is using a custom query, such as `jobAssistance=true`, pagination can be misleading. The root issue is with the line:

`const total = await model.countDocuments();`

This line counts all the documents of a particular collection, which isn't an accurate count when a custom query is being used. The fix is to supply `queryStr` to the `countDocuments()` method.

Credit goes to **_[Kaan](https://www.udemy.com/course/nodejs-api-masterclass/learn/lecture/16582042#questions/10283308)_**, a student from Udemy.