### PR TITLE
fix average cost calculation of a bootcamp when a course gets deleted

### DIFF
--- a/models/Course.js
+++ b/models/Course.js
@@ -71,9 +71,10 @@ CourseSchema.post('save', async function() {
   await this.constructor.getAverageCost(this.bootcamp);
 });
 
-// Call getAverageCost before remove
-CourseSchema.pre('remove', async function() {
+// Call getAverageCost after remove
+CourseSchema.post('remove', async function () {
   await this.constructor.getAverageCost(this.bootcamp);
 });
+
 
 module.exports = mongoose.model('Course', CourseSchema);


### PR DESCRIPTION
When we delete a course, the calculation of average cost is being triggered but the numbers are wrong because we are calculating pre deletion.   
For example if we have two courses, A with tuition 8000 and B with tuition 10000 and we delete B, we keep getting average cost for the bootcamp 9000 instead of 8000, bacause the calculation is done before the deletion of B.
We need to calculate post deletion.