### PR TITLE
avoid db call in getMe - user available from protect

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -68,7 +68,8 @@ exports.logout = asyncHandler(async (req, res, next) => {
 // @route     POST /api/v1/auth/me
 // @access    Private
 exports.getMe = asyncHandler(async (req, res, next) => {
-  const user = await User.findById(req.user.id);
+  // user is already available in req due to the protect middleware
+  const user = req.user;
 
   res.status(200).json({
     success: true,


### PR DESCRIPTION
Spotted by Elimelech Wieder in https://www.udemy.com/course/nodejs-api-masterclass/learn/lecture/16581402#questions/11410426

The user data is already available in the req object because in the protect method we do req.user = await User.findById(decoded.id);

No need to call the db again inside the getMe method, we can just return the user data.