### PR TITLE
For last delted course averageCost goes undefined

### DIFF
--- a/models/Course.js
+++ b/models/Course.js
@@ -60,7 +60,7 @@ CourseSchema.statics.getAverageCost = async function(bootcampId) {
   try {
  if (obj[0]) {
       await this.model("Bootcamp").findByIdAndUpdate(bootcampid, {
-        averageCost: Math.ceil(obj[0].averageCost),
+        averageCost:Math.ceil(obj[0].averageCost / 10) * 10,
       });
     } else {
       await this.model("Bootcamp").findByIdAndUpdate(bootcampid, {

--- a/models/Course.js
+++ b/models/Course.js
@@ -58,9 +58,15 @@ CourseSchema.statics.getAverageCost = async function(bootcampId) {
   ]);
 
   try {
-    await this.model('Bootcamp').findByIdAndUpdate(bootcampId, {
-      averageCost: Math.ceil(obj[0].averageCost / 10) * 10
-    });
+ if (obj[0]) {
+      await this.model("Bootcamp").findByIdAndUpdate(bootcampid, {
+        averageCost: Math.ceil(obj[0].averageCost),
+      });
+    } else {
+      await this.model("Bootcamp").findByIdAndUpdate(bootcampid, {
+        averageCost: undefined,
+      });
+    }
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
With post remove,we have to fix another issue... Suppose a publisher wants deletes all his course...So  he starts deleting his course ,bt as soon as he  deletes his last course an error occurs cannot read property averageCost of undefined....As  obj now returns an empty array ,and we are trying to read this empty array obj[0] below in this line of  code 
Math.ceil(obj[0].averageCost / 10) * 10
....Also due to this the last course gets deleted,bt average cost remains there....So  now there is no course in the bootcamp bt still average cost of bootcamp is there which will be the, cost of last deleted course.......So we can wrap this inside an if else statement so that as soon as obj[0] gets undefined ,  we should not read that line of code mentioned above instead directly  set the averageCost to undefined.....
