### PR TITLE
Delete reviews with bootcamps , as cousres were deleted with respective bootcamp

### DIFF
--- a/models/Bootcamp.js
+++ b/models/Bootcamp.js
@@ -140,6 +140,8 @@ BootcampSchema.pre('save', async function(next) {
 BootcampSchema.pre('remove', async function(next) {
   console.log(`Courses being removed from bootcamp ${this._id}`);
   await this.model('Course').deleteMany({ bootcamp: this._id });
+  console.log(`Reviews being removed from bootcamp ${this._id}`);
+   await this.model('Review').deleteMany({ bootcamp: this._id });
   next();
 });
 

--- a/models/Review.js
+++ b/models/Review.js
@@ -50,11 +50,17 @@ ReviewSchema.statics.getAverageRating = async function(bootcampId) {
     }
   ]);
 
-  try {
-    await this.model('Bootcamp').findByIdAndUpdate(bootcampId, {
-      averageRating: obj[0].averageRating
-    });
-  } catch (err) {
+ try {
+    if (obj[0]) {
+      await this.model("Bootcamp").findByIdAndUpdate(bootcampId, {
+        averageRating: obj[0].averageRating.toFixed(1),
+      });
+    } else {
+      await this.model("Bootcamp").findByIdAndUpdate(bootcampId, {
+        averageRating: undefined,
+      });
+    }
+  }  catch (err) {
     console.error(err);
   }
 };


### PR DESCRIPTION
1. In bootcampSchema we have a pre hook ,that deletes all the courses related to bootcamp ,that is being deleted....

We should do the same for reviews 
because reviews are having a feild named bootcamp of mongoose.ObjectId associated with a particular bootcamp...Now if we delete a bootcamp , without deleting  its review, we will get null  in place of bootcamp mongoose.objectId in reviews that are associated with that bootcamp ,as now that particular  bootcamp is not there or it has been deleted now.....



2. In Reviews model while calculating averageRating we have used post("remove") as in Course model while calculating averageCost..
averageRating: obj[0].averageRating
The  same type of error occurs , obj in above line of code goes undefined as the last review is deleted....We should also replace that with if/else as we have replaced in Course model

3. Also ratings are gernally only upto one decimal places so ,we can use averagerating.toFixed(1) 