### PR TITLE
Allow name OR email update to profile by checking if value exists

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -99,10 +99,14 @@ exports.getMe = asyncHandler(async (req, res, next) => {
 // @route     PUT /api/v1/auth/updatedetails
 // @access    Private
 exports.updateDetails = asyncHandler(async (req, res, next) => {
-  const fieldsToUpdate = {
-    name: req.body.name,
-    email: req.body.email,
-  };
+  const fieldsToUpdate = {};
+//only if fields exists, assign it to fieldsToUpdate object to make sure no property is undefined
+  if (req.body.email) {
+    fieldsToUpdate.email = req.body.email;
+  }
+  if (req.body.name) {
+    fieldsToUpdate.name = req.body.name;
+  }
 
   const user = await User.findByIdAndUpdate(req.user.id, fieldsToUpdate, {
     new: true,


### PR DESCRIPTION
If someone wants to update his profile (name, or email) we only allow him to those two fields with these lines of coe
```
  const fieldsToUpdate = {
    name: req.body.name,
    email: req.body.email,
  };
```
The problem is if he only submits one of the two fields, the other one will be `undefined`, but in our model, both fields are required. So we need to check if a given field exists on `req.body` before we assign it to `fieldsToUpdata`