### PR TITLE
Fix typo in Course model

### DIFF
--- a/models/Course.js
+++ b/models/Course.js
@@ -59,11 +59,11 @@ CourseSchema.statics.getAverageCost = async function(bootcampId) {
 
   try {
  if (obj[0]) {
-      await this.model("Bootcamp").findByIdAndUpdate(bootcampid, {
+      await this.model("Bootcamp").findByIdAndUpdate(bootcampId, {
         averageCost:Math.ceil(obj[0].averageCost / 10) * 10,
       });
     } else {
-      await this.model("Bootcamp").findByIdAndUpdate(bootcampid, {
+      await this.model("Bootcamp").findByIdAndUpdate(bootcampId, {
         averageCost: undefined,
       });
     }


### PR DESCRIPTION
This commit fixes a typo (`bootcampId` vs. `bootcampid`) in one of the recent commits.

Credit: [David](https://www.udemy.com/user/david-souksavat/) @ Udemy.